### PR TITLE
Add github runner user to group docker to use it

### DIFF
--- a/infra/ansible/bastion_provisioner/tasks/install_dependencies.yml
+++ b/infra/ansible/bastion_provisioner/tasks/install_dependencies.yml
@@ -49,3 +49,4 @@
     name: kubectl
     state: present
   become: true
+

--- a/infra/ansible/bastion_provisioner/tasks/register_runner.yml
+++ b/infra/ansible/bastion_provisioner/tasks/register_runner.yml
@@ -9,7 +9,18 @@
     name: "{{ github_runner_user }}"
     group: "{{ github_runner_group }}"
     home: "{{ github_runner_home_dir }}"
+    shell: /bin/bash
     state: present
+  become: true
+
+- name: Ensure users are in the docker group
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: docker
+    append: yes
+  with_list:
+    - "{{ github_runner_user }}"
+    - ubuntu
   become: true
 
 - name: Download GitHub Actions software
@@ -64,6 +75,7 @@
 - name: Setup github runner systemd unit
   ansible.builtin.shell: |
     ./svc.sh install '{{ github_runner_user }}' && ./svc.sh start
+  when: github_credentials_file.stat.exists == False
   args:
     chdir: "{{ github_runner_home_dir }}/actions-runner/"
   become: true


### PR DESCRIPTION
Fix issue:
After the provisioning of the bastion the github-runner user couldn't use docker because it didn't belong to the group. The role was edited to add the user to the group